### PR TITLE
Fix scope & pitch name inputs loosing focus when typing 'A'

### DIFF
--- a/src/app/boards/[roomId]/pitch-dropdown-menu.tsx
+++ b/src/app/boards/[roomId]/pitch-dropdown-menu.tsx
@@ -23,7 +23,10 @@ export function PitchDropdownMenu({
   return (
     <DropdownMenu open={open} onOpenChange={setOpen}>
       <DropdownMenuTrigger asChild>{children}</DropdownMenuTrigger>
-      <DropdownMenuContent>
+      <DropdownMenuContent
+        onKeyDown={(e) => e.stopPropagation()}
+        onKeyDownCapture={(e) => e.stopPropagation()}
+      >
         <PitchDropdownMenuContent pitch={pitch} close={() => setOpen(false)} />
       </DropdownMenuContent>
     </DropdownMenu>

--- a/src/app/boards/[roomId]/scope-dropdown-menu.tsx
+++ b/src/app/boards/[roomId]/scope-dropdown-menu.tsx
@@ -41,7 +41,10 @@ export function ScopeDropdownMenu({
   return (
     <DropdownMenu open={open} onOpenChange={setOpen}>
       <DropdownMenuTrigger asChild>{children}</DropdownMenuTrigger>
-      <DropdownMenuContent>
+      <DropdownMenuContent
+        onKeyDown={(e) => e.stopPropagation()}
+        onKeyDownCapture={(e) => e.stopPropagation()}
+      >
         <ScopeDropdownMenuContent scope={scope} close={() => setOpen(false)} />
       </DropdownMenuContent>
     </DropdownMenu>

--- a/src/app/boards/board-context-menu.tsx
+++ b/src/app/boards/board-context-menu.tsx
@@ -32,7 +32,10 @@ export function BoardContextMenu({
             <Ellipsis className="size-4" />
           </Button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent>
+        <DropdownMenuContent
+          onKeyDown={(e) => e.stopPropagation()}
+          onKeyDownCapture={(e) => e.stopPropagation()}
+        >
           <DialogTrigger asChild>
             <DropdownMenuItem>Board settings…</DropdownMenuItem>
           </DialogTrigger>


### PR DESCRIPTION
Because of a conflict with keyboard navigation in a dropdown, the focus used to leave the input when typing `A`.

Solution: disable keyboard navigation in the dropdown (not ideal). 

Same problem/solution for pitch name.