### PR TITLE
Add MCP server for Claude integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,71 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+npm run dev      # Start dev server on localhost:3000
+npm run build    # Production build
+npm run lint     # ESLint via Next.js
+```
+
+No test framework is configured.
+
+## Environment Variables
+
+Required in `.env.local` (validated via Zod in `src/env.ts`):
+
+- `NEXT_PUBLIC_LIVEBLOCKS_API_KEY` - Liveblocks public key
+- `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` - Clerk public key
+- `LIVEBLOCKS_SECRET_KEY` - Liveblocks server secret
+- `CLERK_SECRET_KEY` - Clerk server secret
+
+## Architecture
+
+**Cycles** is a real-time collaborative project planning app built with Next.js 14 (App Router), using Liveblocks for CRDT-based multiplayer state and Clerk for authentication.
+
+### Data Layer — Liveblocks (no database)
+
+All persistent data lives in Liveblocks rooms as `LiveList<LiveObject<T>>` collections. There is no traditional database. The core types are defined in `src/liveblocks.config.ts`:
+
+- **Pitch** — a project/bet (has scopes)
+- **Scope** — a work area within a pitch (has tasks, progress, effort/impact, color, core/optional/out flags)
+- **Task** — a work item within a scope (status: todo/in_progress/done, type: task/optional/bug/question)
+- **PitchSnapshot** — point-in-time snapshot of pitch progress
+
+State is read with `useStorage()` and mutated with `useMutation()` (both from `src/liveblocks.config.ts` suspense exports). Presence tracks which pitch each user is viewing.
+
+### Auth Flow
+
+1. Clerk handles user auth and organization management (middleware in `src/middleware.ts`)
+2. `POST /api/liveblocks-auth` creates a Liveblocks session scoped to the user's org rooms (`${orgId}:*`)
+3. Room IDs follow the pattern `${orgId}:${roomSlug}` (or `${userId}:${roomSlug}` for personal boards)
+
+### Routing
+
+- `/` → redirects to `/boards`
+- `/boards` — board list (server component, org-aware)
+- `/boards/[roomId]` — board detail; server component loads room metadata, then renders `room.tsx` client component with `RoomProvider`
+- `/api/liveblocks-auth` — Liveblocks auth endpoint
+
+### Component Patterns
+
+- Server components handle auth, data fetching, and org user lists; client components (`"use client"`) handle all interactive UI
+- UI primitives from shadcn/ui (Radix-based) in `src/components/ui/`
+- Drag-and-drop via dnd-kit (pitch reordering, task movement, scope dragging on hill chart)
+- React Contexts for cross-component state: `SelectedPitchContext`, `SidePanelCollapsedContext`, `OrganizationUsersContext`, `HoveredScopeContext`
+- Board-level server actions (`createRoom`, `updateBoard`, `archiveBoard`, `restoreBoard`) in `src/app/boards/board-context-menu.actions.ts`
+
+### Key Libraries
+
+- **Liveblocks** — real-time sync, CRDT storage, presence, undo/redo
+- **Clerk** — auth, orgs, user metadata
+- **dnd-kit** — drag and drop
+- **SWR** — data fetching/caching
+- **ts-pattern** — pattern matching
+- **next-themes** — dark mode (class-based)
+
+### Path Aliases
+
+`@/*` maps to `./src/*` (configured in tsconfig.json).

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,17 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  async rewrites() {
+    return [
+      {
+        source: '/.well-known/oauth-authorization-server',
+        destination: '/api/well-known/oauth-authorization-server',
+      },
+      {
+        source: '/.well-known/oauth-protected-resource/mcp',
+        destination: '/api/well-known/oauth-protected-resource/mcp',
+      },
+    ]
+  },
+};
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "cycles-next",
       "version": "0.1.0",
       "dependencies": {
-        "@clerk/nextjs": "^5.0.12",
+        "@clerk/mcp-tools": "^0.3.1",
+        "@clerk/nextjs": "^6.37.3",
         "@dnd-kit/modifiers": "^7.0.0",
         "@dnd-kit/sortable": "^8.0.0",
         "@liveblocks/client": "^1.12.0",
@@ -24,13 +25,14 @@
         "@radix-ui/react-slot": "^1.0.2",
         "@radix-ui/react-toast": "^1.2.1",
         "@radix-ui/react-tooltip": "^1.1.0",
+        "@vercel/mcp-adapter": "^1.0.0",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
         "date-fns": "^3.6.0",
         "lodash": "^4.17.21",
         "lucide-react": "^0.378.0",
         "nanoid": "^5.0.7",
-        "next": "14.2.3",
+        "next": "^14.2.35",
         "next-themes": "^0.3.0",
         "react": "^18",
         "react-dom": "^18",
@@ -39,7 +41,7 @@
         "tailwind-merge": "^2.3.0",
         "tailwindcss-animate": "^1.0.7",
         "ts-pattern": "^5.1.1",
-        "zod": "^3.23.8"
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@total-typescript/ts-reset": "^0.5.1",
@@ -77,89 +79,104 @@
       }
     },
     "node_modules/@clerk/backend": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-1.1.5.tgz",
-      "integrity": "sha512-e1CD4A5y+H4NbGdGJSE1ZnLGAYaFssrG7NStMmpwaOJry7zF0AbcMMrTzPGWoeu9xrrIRllcOMnAzhehe0/kYg==",
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-2.30.1.tgz",
+      "integrity": "sha512-GoxnJzVH0ycNPAGCDMfo3lPBFbo5nehpLSVFjgGEnzIRGGahBtAB8PQT7KM2zo58pD8apjb/+suhcB/WCiEasQ==",
+      "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "2.1.1",
-        "cookie": "0.5.0",
-        "snakecase-keys": "5.4.4",
-        "tslib": "2.4.1"
+        "@clerk/shared": "^3.44.0",
+        "@clerk/types": "^4.101.14",
+        "standardwebhooks": "^1.0.0",
+        "tslib": "2.8.1"
       },
       "engines": {
         "node": ">=18.17.0"
       }
-    },
-    "node_modules/@clerk/backend/node_modules/tslib": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/@clerk/clerk-react": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@clerk/clerk-react/-/clerk-react-5.1.0.tgz",
-      "integrity": "sha512-drc/V0J+h9Jsz32QsL7WmuUhhhkU21KbNz5mwLPbSzBMoLg43sx6aRjJGCfBQYPxPsuFZWDlKoJhX6LZ8yxHcA==",
+      "version": "5.60.0",
+      "resolved": "https://registry.npmjs.org/@clerk/clerk-react/-/clerk-react-5.60.0.tgz",
+      "integrity": "sha512-P88FncsJpq/3WZJhhlj+md8mYb35BIXpr462C/figwsBGHsinr8VuBQUMcMZZ/6M34C8ABfLTPa6PHVp6+3D5Q==",
+      "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "2.1.1",
-        "@clerk/types": "4.4.0",
-        "tslib": "2.4.1"
+        "@clerk/shared": "^3.44.0",
+        "tslib": "2.8.1"
       },
       "engines": {
         "node": ">=18.17.0"
       },
       "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
+        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
+        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
       }
     },
-    "node_modules/@clerk/clerk-react/node_modules/tslib": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+    "node_modules/@clerk/mcp-tools": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@clerk/mcp-tools/-/mcp-tools-0.3.1.tgz",
+      "integrity": "sha512-c/7bmT9KxA3CYVhCS08RGmVwjU8+zJ6ZCuIA5KpcJfE5xh8XLKKvZzOD4mP0GgvUGjcnT+IViaqBRlRKAyE5rw==",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.17.0"
+      },
+      "peerDependencies": {
+        "better-sqlite3": "^8.7.0",
+        "pg": "^8.11.0",
+        "redis": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "better-sqlite3": {
+          "optional": true
+        },
+        "pg": {
+          "optional": true
+        },
+        "redis": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@clerk/nextjs": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/@clerk/nextjs/-/nextjs-5.0.12.tgz",
-      "integrity": "sha512-uRbt31bfPOhQw14wJUThVGlP1HT2v7Ii+UY00MWFuyx7RmOUgqDnBax2FhUcCEJJhICSU0Xf/TqrWOkQUTEg/A==",
+      "version": "6.37.3",
+      "resolved": "https://registry.npmjs.org/@clerk/nextjs/-/nextjs-6.37.3.tgz",
+      "integrity": "sha512-kammmf4b5R2Izb/SN4UbEa/6rdyop9fPHwZkyyJoVfgMLFM26fwpXWaSqVJPe4YL2BmHKP+orIOolzTmEhhdQQ==",
+      "license": "MIT",
       "dependencies": {
-        "@clerk/backend": "1.1.5",
-        "@clerk/clerk-react": "5.1.0",
-        "@clerk/shared": "2.1.1",
-        "crypto-js": "4.2.0",
-        "path-to-regexp": "6.2.1",
-        "tslib": "2.4.1"
+        "@clerk/backend": "^2.30.1",
+        "@clerk/clerk-react": "^5.60.0",
+        "@clerk/shared": "^3.44.0",
+        "@clerk/types": "^4.101.14",
+        "server-only": "0.0.1",
+        "tslib": "2.8.1"
       },
       "engines": {
         "node": ">=18.17.0"
       },
       "peerDependencies": {
-        "next": "^13.5.4 || ^14.0.3",
-        "react": ">=18",
-        "react-dom": ">=18"
+        "next": "^13.5.7 || ^14.2.25 || ^15.2.3 || ^16",
+        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
+        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
       }
     },
-    "node_modules/@clerk/nextjs/node_modules/tslib": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
-    },
     "node_modules/@clerk/shared": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-2.1.1.tgz",
-      "integrity": "sha512-cj8VZdEtuqghHBFApl2fFgBtjYZ0NN085uXPqSvdBS62EIKpSENCqm7Ug1H5R2WSuCIv819ZZEBxPiYZM0TNFg==",
+      "version": "3.44.0",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.44.0.tgz",
+      "integrity": "sha512-kH+chNeZwqml3IDpWLgebWECfOZifyUQO4OISd/96w1EuCY1Bzw6cBq/ZbpsoO8jyG8/6bGr/MGXLhDzTrpPfA==",
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
+        "csstype": "3.1.3",
+        "dequal": "2.0.3",
         "glob-to-regexp": "0.4.1",
-        "js-cookie": "3.0.1",
-        "std-env": "^3.7.0",
-        "swr": "2.2.0"
+        "js-cookie": "3.0.5",
+        "std-env": "^3.9.0",
+        "swr": "2.3.4"
       },
       "engines": {
         "node": ">=18.17.0"
       },
       "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
+        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
+        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
       },
       "peerDependenciesMeta": {
         "react": {
@@ -170,32 +187,17 @@
         }
       }
     },
-    "node_modules/@clerk/shared/node_modules/swr": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/swr/-/swr-2.2.0.tgz",
-      "integrity": "sha512-AjqHOv2lAhkuUdIiBu9xbuettzAzWXmCEcLONNKJRba87WAefz8Ca9d6ds/SzrPc235n1IxWYdhJ2zF3MNUaoQ==",
-      "dependencies": {
-        "use-sync-external-store": "^1.2.0"
-      },
-      "peerDependencies": {
-        "react": "^16.11.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
     "node_modules/@clerk/types": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-4.4.0.tgz",
-      "integrity": "sha512-OaT02uLG1P/jBFNyoPM3n9nLdV4H0etTpa/l3iTW4IgOLiAINToLpMOvEpWzKWUq9nvmOouZlBzPVMozu7dwDg==",
+      "version": "4.101.14",
+      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-4.101.14.tgz",
+      "integrity": "sha512-jl7DywmeaZx1IntgEXcjDZq2uyk+X/1yAZOjxOboeGTS0rNTiQNhv7xK8tFVjexsUAFrYlwC1AxhFuJiMDQjow==",
+      "license": "MIT",
       "dependencies": {
-        "csstype": "3.1.1"
+        "@clerk/shared": "^3.44.0"
       },
       "engines": {
         "node": ">=18.17.0"
       }
-    },
-    "node_modules/@clerk/types/node_modules/csstype": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
-      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
     },
     "node_modules/@dnd-kit/accessibility": {
       "version": "3.1.0",
@@ -350,6 +352,18 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.2.tgz",
       "integrity": "sha512-J4yDIIthosAsRZ5CPYP/jQvUAQtlZTTD/4suA08/FEnlxqW3sKS9iAhgsa9VYLZ6vDHn/ixJgIqRQPotoBjxIw=="
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.9",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
+      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
@@ -523,10 +537,81 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.25.2",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.25.2.tgz",
+      "integrity": "sha512-LZFeo4F9M5qOhC/Uc1aQSrBHxMrvxett+9KLHt7OhcExtoiRN9DKgbZffMP/nxjutWDQpfMDfP3nkHI4X9ijww==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.7",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.0.1",
+        "express-rate-limit": "^7.5.0",
+        "jose": "^6.1.1",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/zod-to-json-schema": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
+      }
+    },
     "node_modules/@next/env": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.3.tgz",
-      "integrity": "sha512-W7fd7IbkfmeeY2gXrzJYDx8D2lWKbVoTIj1o1ScPHNzvp30s1AuoEFSdr39bC5sjxJaxTtq3OTCZboNp0lNWHA=="
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.35.tgz",
+      "integrity": "sha512-DuhvCtj4t9Gwrx80dmz2F4t/zKQ4ktN8WrMwOuVzkJfBilwAwGr6v16M5eI8yCuZ63H9TTuEU09Iu2HqkzFPVQ==",
+      "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
       "version": "14.2.3",
@@ -538,12 +623,13 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.3.tgz",
-      "integrity": "sha512-3pEYo/RaGqPP0YzwnlmPN2puaF2WMLM3apt5jLW2fFdXD9+pqcoTzRk+iZsf8ta7+quAe4Q6Ms0nR0SFGFdS1A==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.33.tgz",
+      "integrity": "sha512-HqYnb6pxlsshoSTubdXKu15g3iivcbsMXg4bYpjL2iS/V6aQot+iyF4BUc2qA/J/n55YtvE4PHMKWBKGCF/+wA==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -553,12 +639,13 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.3.tgz",
-      "integrity": "sha512-6adp7waE6P1TYFSXpY366xwsOnEXM+y1kgRpjSRVI2CBDOcbRjsJ67Z6EgKIqWIue52d2q/Mx8g9MszARj8IEA==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.33.tgz",
+      "integrity": "sha512-8HGBeAE5rX3jzKvF593XTTFg3gxeU4f+UWnswa6JPhzaR6+zblO5+fjltJWIZc4aUalqTclvN2QtTC37LxvZAA==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -568,12 +655,13 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.3.tgz",
-      "integrity": "sha512-cuzCE/1G0ZSnTAHJPUT1rPgQx1w5tzSX7POXSLaS7w2nIUJUD+e25QoXD/hMfxbsT9rslEXugWypJMILBj/QsA==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.33.tgz",
+      "integrity": "sha512-JXMBka6lNNmqbkvcTtaX8Gu5by9547bukHQvPoLe9VRBx1gHwzf5tdt4AaezW85HAB3pikcvyqBToRTDA4DeLw==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -583,12 +671,13 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.3.tgz",
-      "integrity": "sha512-0D4/oMM2Y9Ta3nGuCcQN8jjJjmDPYpHX9OJzqk42NZGJocU2MqhBq5tWkJrUQOQY9N+In9xOdymzapM09GeiZw==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.33.tgz",
+      "integrity": "sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -598,12 +687,13 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.3.tgz",
-      "integrity": "sha512-ENPiNnBNDInBLyUU5ii8PMQh+4XLr4pG51tOp6aJ9xqFQ2iRI6IH0Ds2yJkAzNV1CfyagcyzPfROMViS2wOZ9w==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.33.tgz",
+      "integrity": "sha512-FnFn+ZBgsVMbGDsTqo8zsnRzydvsGV8vfiWwUo1LD8FTmPTdV+otGSWKc4LJec0oSexFnCYVO4hX8P8qQKaSlg==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -613,12 +703,13 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.3.tgz",
-      "integrity": "sha512-BTAbq0LnCbF5MtoM7I/9UeUu/8ZBY0i8SFjUMCbPDOLv+un67e2JgyN4pmgfXBwy/I+RHu8q+k+MCkDN6P9ViQ==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.33.tgz",
+      "integrity": "sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -628,12 +719,13 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.3.tgz",
-      "integrity": "sha512-AEHIw/dhAMLNFJFJIJIyOFDzrzI5bAjI9J26gbO5xhAKHYTZ9Or04BesFPXiAYXDNdrwTP2dQceYA4dL1geu8A==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.33.tgz",
+      "integrity": "sha512-nscpt0G6UCTkrT2ppnJnFsYbPDQwmum4GNXYTeoTIdsmMydSKFz9Iny2jpaRupTb+Wl298+Rh82WKzt9LCcqSQ==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -643,12 +735,13 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.3.tgz",
-      "integrity": "sha512-vga40n1q6aYb0CLrM+eEmisfKCR45ixQYXuBXxOOmmoV8sYST9k7E3US32FsY+CkkF7NtzdcebiFT4CHuMSyZw==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.33.tgz",
+      "integrity": "sha512-pc9LpGNKhJ0dXQhZ5QMmYxtARwwmWLpeocFmVG5Z0DzWq5Uf0izcI8tLc+qOpqxO1PWqZ5A7J1blrUIKrIFc7Q==",
       "cpu": [
         "ia32"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -658,12 +751,13 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.3.tgz",
-      "integrity": "sha512-Q1/zm43RWynxrO7lW4ehciQVj+5ePBhOK+/K2P7pLFX3JaJ/IZVC69SHidrmZSOkqz7ECIOhhy7XhAFG4JYyHA==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.33.tgz",
+      "integrity": "sha512-nOjfZMy8B94MdisuzZo9/57xuFVLHJaDj5e/xrduJp9CV2/HrfxTRH2fbyLe+K9QT41WBLUd4iXX3R7jBp0EUg==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -2208,6 +2302,65 @@
         "@babel/runtime": "^7.13.10"
       }
     },
+    "node_modules/@redis/bloom": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
+      "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.1.tgz",
+      "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2",
+        "generic-pool": "3.9.0",
+        "yallist": "4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@redis/graph": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.1.tgz",
+      "integrity": "sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.7.tgz",
+      "integrity": "sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.2.0.tgz",
+      "integrity": "sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.1.0.tgz",
+      "integrity": "sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
     "node_modules/@rushstack/eslint-patch": {
       "version": "1.10.3",
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.10.3.tgz",
@@ -2418,6 +2571,44 @@
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
     },
+    "node_modules/@vercel/mcp-adapter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@vercel/mcp-adapter/-/mcp-adapter-1.0.0.tgz",
+      "integrity": "sha512-o/QA4LhYCJvuL7/i8CfKPpOm29u25/L4m1LWH44EQZ8cfYJlc4B7Bu+YzDHl23m8A3hDxCJQmlgZEGmsPAQ0vQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mcp-handler": "^1.0.0"
+      },
+      "bin": {
+        "create-mcp-route": "dist/cli/index.js",
+        "mcp-adapter": "dist/cli/index.js"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.12.0",
+        "next": ">=13.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": false
+        },
+        "next": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.11.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
@@ -2454,6 +2645,45 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
@@ -2748,6 +2978,30 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -2780,6 +3034,15 @@
         "node": ">=10.16.0"
       }
     },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
@@ -2791,6 +3054,35 @@
         "function-bind": "^1.1.2",
         "get-intrinsic": "^1.2.4",
         "set-function-length": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2917,6 +3209,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2947,18 +3248,59 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
-    "node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -2967,11 +3309,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/crypto-js": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
-      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
@@ -2987,8 +3324,7 @@
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "devOptional": true
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -3057,12 +3393,12 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -3113,11 +3449,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -3161,13 +3505,18 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/dot-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
-      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
       "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/eastasianwidth": {
@@ -3175,10 +3524,25 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
     },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/enhanced-resolve": {
       "version": "5.16.1",
@@ -3254,13 +3618,10 @@
       }
     },
     "node_modules/es-define-property": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
-      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
-      "dev": true,
-      "dependencies": {
-        "get-intrinsic": "^1.2.4"
-      },
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
@@ -3269,7 +3630,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -3300,10 +3660,10 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
-      "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
-      "dev": true,
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -3350,6 +3710,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -3775,11 +4141,107 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
+      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/express/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-glob": {
       "version": "3.3.2",
@@ -3824,6 +4286,22 @@
       "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
       "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ=="
     },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fastq": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
@@ -3853,6 +4331,27 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/find-up": {
@@ -3915,6 +4414,24 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -3969,17 +4486,31 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/generic-pool": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/get-intrinsic": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
-      "dev": true,
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
       "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
         "function-bind": "^1.1.2",
-        "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3",
-        "hasown": "^2.0.0"
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3994,6 +4525,19 @@
       "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-symbol-description": {
@@ -4060,7 +4604,8 @@
     "node_modules/glob-to-regexp": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/glob/node_modules/brace-expansion": {
       "version": "2.0.1",
@@ -4136,12 +4681,12 @@
       }
     },
     "node_modules/gopd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-      "dev": true,
-      "dependencies": {
-        "get-intrinsic": "^1.1.3"
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4201,10 +4746,10 @@
       }
     },
     "node_modules/has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-      "dev": true,
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -4236,6 +4781,52 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.11.9",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.9.tgz",
+      "integrity": "sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ignore": {
@@ -4285,8 +4876,7 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/internal-slot": {
       "version": "1.0.7",
@@ -4308,6 +4898,15 @@
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "dependencies": {
         "loose-envify": "^1.0.0"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/is-array-buffer": {
@@ -4543,6 +5142,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
@@ -4720,12 +5325,22 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/jose": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
+      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-cookie": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.1.tgz",
-      "integrity": "sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "license": "MIT",
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/js-tokens": {
@@ -4756,6 +5371,12 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -4880,14 +5501,6 @@
         "loose-envify": "cli.js"
       }
     },
-    "node_modules/lower-case": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
-      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
     "node_modules/lru-cache": {
       "version": "10.2.2",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.2.tgz",
@@ -4904,12 +5517,80 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
       }
     },
-    "node_modules/map-obj": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
-      "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mcp-handler": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/mcp-handler/-/mcp-handler-1.0.7.tgz",
+      "integrity": "sha512-w2wHb6IVmbiS+pnBNb5BXaSd+ynSgExNauB55gUwoHDw8Q8Ew9TVMsSX89yItmex61zQTl+/NuSYmlOgSpj8SQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^11.1.0",
+        "redis": "^4.6.0"
+      },
+      "bin": {
+        "create-mcp-route": "dist/cli/index.js",
+        "mcp-adapter": "dist/cli/index.js",
+        "mcp-handler": "dist/cli/index.js"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "1.25.2",
+        "next": ">=13.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": false
+        },
+        "next": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mcp-handler/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/mcp-handler/node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -4933,6 +5614,31 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/minimatch": {
@@ -4965,10 +5671,10 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/mz": {
       "version": "2.7.0",
@@ -5003,12 +5709,22 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/next": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/next/-/next-14.2.3.tgz",
-      "integrity": "sha512-dowFkFTR8v79NPJO4QsBUtxv0g9BrS/phluVpMAt2ku7H+cbcBJlopXjkWlwxrk/xGqMemr7JkGPGemPrLLX7A==",
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.2.35.tgz",
+      "integrity": "sha512-KhYd2Hjt/O1/1aZVX3dCwGXM1QmOV4eNM2UTacK5gipDdPN/oHHK/4oVGy7X8GMfPMsUTUEmGlsy0EY1YGAkig==",
+      "license": "MIT",
       "dependencies": {
-        "@next/env": "14.2.3",
+        "@next/env": "14.2.35",
         "@swc/helpers": "0.5.5",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001579",
@@ -5023,15 +5739,15 @@
         "node": ">=18.17.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "14.2.3",
-        "@next/swc-darwin-x64": "14.2.3",
-        "@next/swc-linux-arm64-gnu": "14.2.3",
-        "@next/swc-linux-arm64-musl": "14.2.3",
-        "@next/swc-linux-x64-gnu": "14.2.3",
-        "@next/swc-linux-x64-musl": "14.2.3",
-        "@next/swc-win32-arm64-msvc": "14.2.3",
-        "@next/swc-win32-ia32-msvc": "14.2.3",
-        "@next/swc-win32-x64-msvc": "14.2.3"
+        "@next/swc-darwin-arm64": "14.2.33",
+        "@next/swc-darwin-x64": "14.2.33",
+        "@next/swc-linux-arm64-gnu": "14.2.33",
+        "@next/swc-linux-arm64-musl": "14.2.33",
+        "@next/swc-linux-x64-gnu": "14.2.33",
+        "@next/swc-linux-x64-musl": "14.2.33",
+        "@next/swc-win32-arm64-msvc": "14.2.33",
+        "@next/swc-win32-ia32-msvc": "14.2.33",
+        "@next/swc-win32-x64-msvc": "14.2.33"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -5105,15 +5821,6 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/no-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
-      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-      "dependencies": {
-        "lower-case": "^2.0.2",
-        "tslib": "^2.0.3"
-      }
-    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -5158,10 +5865,13 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
-      "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
-      "dev": true,
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -5273,11 +5983,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -5341,6 +6062,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -5387,11 +6117,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/path-to-regexp": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
-      "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw=="
-    },
     "node_modules/path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -5431,6 +6156,15 @@
       "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -5620,6 +6354,19 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -5627,6 +6374,21 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/queue-microtask": {
@@ -5647,6 +6409,30 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/react": {
       "version": "18.3.1",
@@ -5772,6 +6558,23 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/redis": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-4.7.1.tgz",
+      "integrity": "sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==",
+      "license": "MIT",
+      "workspaces": [
+        "./packages/*"
+      ],
+      "dependencies": {
+        "@redis/bloom": "1.2.0",
+        "@redis/client": "1.6.1",
+        "@redis/graph": "1.1.1",
+        "@redis/json": "1.0.7",
+        "@redis/search": "1.2.0",
+        "@redis/time-series": "1.1.0"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.6.tgz",
@@ -5814,6 +6617,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
@@ -5894,6 +6706,32 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -5951,6 +6789,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -5970,6 +6814,57 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -6003,6 +6898,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -6023,15 +6924,69 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
-      "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
-      "dev": true,
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.4",
-        "object-inspect": "^1.13.1"
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6060,39 +7015,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/snake-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
-      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/snakecase-keys": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/snakecase-keys/-/snakecase-keys-5.4.4.tgz",
-      "integrity": "sha512-YTywJG93yxwHLgrYLZjlC75moVEX04LZM4FHfihjHe1FCXm+QaLOFfSf535aXOAd0ArVQMWUAe8ZPm4VtWyXaA==",
-      "dependencies": {
-        "map-obj": "^4.1.0",
-        "snake-case": "^3.0.4",
-        "type-fest": "^2.5.2"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/snakecase-keys/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
@@ -6101,10 +7023,30 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/std-env": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.7.0.tgz",
-      "integrity": "sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg=="
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "license": "MIT"
     },
     "node_modules/streamsearch": {
       "version": "1.1.0",
@@ -6360,15 +7302,16 @@
       }
     },
     "node_modules/swr": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/swr/-/swr-2.2.5.tgz",
-      "integrity": "sha512-QtxqyclFeAsxEUeZIYmsaQ0UjimSq1RZ9Un7I68/0ClKK/U3LoyQunwkQfJZr2fc22DfIXLNDc2wFyTEikCUpg==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.4.tgz",
+      "integrity": "sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg==",
+      "license": "MIT",
       "dependencies": {
-        "client-only": "^0.0.1",
-        "use-sync-external-store": "^1.2.0"
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.4.0"
       },
       "peerDependencies": {
-        "react": "^16.11.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/tailwind-merge": {
@@ -6472,6 +7415,15 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -6512,9 +7464,10 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -6538,6 +7491,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/typed-array-buffer": {
@@ -6647,6 +7614,15 @@
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -6698,17 +7674,27 @@
       }
     },
     "node_modules/use-sync-external-store": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz",
-      "integrity": "sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
@@ -6916,8 +7902,13 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
     },
     "node_modules/yaml": {
       "version": "2.4.2",
@@ -6943,9 +7934,10 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.23.8",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
-      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@clerk/nextjs": "^5.0.12",
+    "@clerk/mcp-tools": "^0.3.1",
+    "@clerk/nextjs": "^6.37.3",
     "@dnd-kit/modifiers": "^7.0.0",
     "@dnd-kit/sortable": "^8.0.0",
     "@liveblocks/client": "^1.12.0",
@@ -25,13 +26,14 @@
     "@radix-ui/react-slot": "^1.0.2",
     "@radix-ui/react-toast": "^1.2.1",
     "@radix-ui/react-tooltip": "^1.1.0",
+    "@vercel/mcp-adapter": "^1.0.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "date-fns": "^3.6.0",
     "lodash": "^4.17.21",
     "lucide-react": "^0.378.0",
     "nanoid": "^5.0.7",
-    "next": "14.2.3",
+    "next": "^14.2.35",
     "next-themes": "^0.3.0",
     "react": "^18",
     "react-dom": "^18",
@@ -40,7 +42,7 @@
     "tailwind-merge": "^2.3.0",
     "tailwindcss-animate": "^1.0.7",
     "ts-pattern": "^5.1.1",
-    "zod": "^3.23.8"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@total-typescript/ts-reset": "^0.5.1",

--- a/src/app/api/get-organization-users.ts
+++ b/src/app/api/get-organization-users.ts
@@ -3,7 +3,7 @@ import { auth } from '@clerk/nextjs/server'
 import { NextResponse } from 'next/server'
 
 export async function GET() {
-  const { userId, orgId } = auth()
+  const { userId, orgId } = await auth()
   if (!userId) {
     return NextResponse.json({ error: 'Not authorized' }, { status: 401 })
   }

--- a/src/app/api/liveblocks-auth/route.ts
+++ b/src/app/api/liveblocks-auth/route.ts
@@ -3,7 +3,7 @@ import { auth, currentUser } from '@clerk/nextjs/server'
 import { NextResponse } from 'next/server'
 
 export async function POST(request: Request) {
-  const { userId, orgId } = auth()
+  const { userId, orgId } = await auth()
   if (!userId) {
     return new NextResponse('Unauthorized', { status: 401 })
   }

--- a/src/app/api/well-known/oauth-authorization-server/route.ts
+++ b/src/app/api/well-known/oauth-authorization-server/route.ts
@@ -1,0 +1,49 @@
+const corsHeaders: Record<string, string> = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, OPTIONS',
+  'Access-Control-Allow-Headers': '*',
+  'Access-Control-Max-Age': '86400',
+}
+
+function deriveFapiUrl(publishableKey: string) {
+  const key = publishableKey.replace(/^pk_(test|live)_/, '')
+  const decoded = Buffer.from(key, 'base64').toString('utf8')
+  return `https://${decoded.replace(/\$/, '')}`
+}
+
+export async function GET() {
+  const publishableKey = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
+  if (!publishableKey) {
+    return new Response(
+      JSON.stringify({ error: 'Missing NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY' }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } }
+    )
+  }
+
+  try {
+    const fapiUrl = deriveFapiUrl(publishableKey)
+    const res = await fetch(
+      `${fapiUrl}/.well-known/oauth-authorization-server`,
+      { cache: 'no-store' }
+    )
+    const metadata = await res.json()
+
+    return new Response(JSON.stringify(metadata), {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'max-age=3600',
+        ...corsHeaders,
+      },
+    })
+  } catch (e) {
+    return new Response(JSON.stringify({ error: String(e) }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+}
+
+export function OPTIONS() {
+  return new Response(null, { status: 200, headers: corsHeaders })
+}

--- a/src/app/api/well-known/oauth-protected-resource/mcp/route.ts
+++ b/src/app/api/well-known/oauth-protected-resource/mcp/route.ts
@@ -1,0 +1,46 @@
+const corsHeaders: Record<string, string> = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, OPTIONS',
+  'Access-Control-Allow-Headers': '*',
+  'Access-Control-Max-Age': '86400',
+}
+
+function deriveFapiUrl(publishableKey: string) {
+  const key = publishableKey.replace(/^pk_(test|live)_/, '')
+  const decoded = Buffer.from(key, 'base64').toString('utf8')
+  return `https://${decoded.replace(/\$/, '')}`
+}
+
+export function GET(req: Request) {
+  const publishableKey = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
+  if (!publishableKey) {
+    return new Response(
+      JSON.stringify({ error: 'Missing NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY' }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } }
+    )
+  }
+
+  const origin = new URL(req.url).origin
+  const fapiUrl = deriveFapiUrl(publishableKey)
+
+  const metadata = {
+    resource: origin,
+    authorization_servers: [fapiUrl],
+    token_types_supported: ['Bearer'],
+    scopes_supported: ['profile', 'email'],
+    bearer_methods_supported: ['header'],
+  }
+
+  return new Response(JSON.stringify(metadata), {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json',
+      'Cache-Control': 'max-age=3600',
+      ...corsHeaders,
+    },
+  })
+}
+
+export function OPTIONS() {
+  return new Response(null, { status: 200, headers: corsHeaders })
+}

--- a/src/app/boards/[roomId]/page.tsx
+++ b/src/app/boards/[roomId]/page.tsx
@@ -9,8 +9,8 @@ export default async function RoomPage({
 }: {
   params: { roomId: string }
 }) {
-  const { userId, orgId } = auth()
-  if (!userId) auth().redirectToSignIn()
+  const { userId, orgId } = await auth()
+  if (!userId) (await auth()).redirectToSignIn()
 
   const roomPrefix = orgId ?? userId
 

--- a/src/app/boards/board-context-menu.actions.ts
+++ b/src/app/boards/board-context-menu.actions.ts
@@ -5,7 +5,7 @@ import { auth } from '@clerk/nextjs/server'
 import { revalidatePath } from 'next/cache'
 
 export async function archiveBoard(roomId: string) {
-  const { orgId, userId } = auth()
+  const { orgId, userId } = await auth()
   if (!roomId.startsWith(`${orgId ?? userId}:`)) throw new Error('Unauthorized')
 
   await liveblocks.updateRoom(roomId, { metadata: { archived: 'yes' } })
@@ -13,7 +13,7 @@ export async function archiveBoard(roomId: string) {
 }
 
 export async function restoreBoard(roomId: string) {
-  const { orgId, userId } = auth()
+  const { orgId, userId } = await auth()
   if (!roomId.startsWith(`${orgId ?? userId}:`)) throw new Error('Unauthorized')
 
   await liveblocks.updateRoom(roomId, { metadata: { archived: null } })

--- a/src/app/boards/page.tsx
+++ b/src/app/boards/page.tsx
@@ -22,8 +22,8 @@ import Link from 'next/link'
 import { redirect } from 'next/navigation'
 
 export default async function OrganizationsPage() {
-  const { userId, orgId } = auth()
-  if (!userId) return auth().redirectToSignIn()
+  const { userId, orgId } = await auth()
+  if (!userId) return (await auth()).redirectToSignIn()
 
   const roomPrefix = orgId ?? userId
   const { data: rooms } = await liveblocks.getRooms({
@@ -120,7 +120,7 @@ async function BoardListItem({ room }: { room: RoomInfo }) {
     ? new Date(String(room.metadata.createdOn))
     : null
   const createdByUser = room.metadata.createdBy
-    ? await clerkClient.users.getUser(String(room.metadata.createdBy))
+    ? await (await clerkClient()).users.getUser(String(room.metadata.createdBy))
     : null
 
   return (
@@ -193,7 +193,7 @@ async function BoardListItem({ room }: { room: RoomInfo }) {
 async function updateBoard(formData: FormData) {
   'use server'
 
-  const { userId, orgId } = auth()
+  const { userId, orgId } = await auth()
   if (!userId) throw new Error('Not authenticated')
 
   const roomId = formData.get('roomId')
@@ -232,7 +232,7 @@ async function updateBoard(formData: FormData) {
 async function createRoom(formData: FormData) {
   'use server'
 
-  const { userId, orgId } = auth()
+  const { userId, orgId } = await auth()
   if (!userId) throw new Error('Not authenticated')
 
   const roomPrefix = orgId ?? userId

--- a/src/app/mcp/[transport]/route.ts
+++ b/src/app/mcp/[transport]/route.ts
@@ -1,0 +1,60 @@
+import { createMcpHandler, withMcpAuth } from '@vercel/mcp-adapter'
+import { createClerkClient } from '@clerk/backend'
+import { registerBoardTools } from '@/lib/mcp/boards'
+import { registerPitchTools } from '@/lib/mcp/pitches'
+import { registerScopeTools } from '@/lib/mcp/scopes'
+import { registerTaskTools } from '@/lib/mcp/tasks'
+
+const handler = createMcpHandler(
+  (server) => {
+    registerBoardTools(server)
+    registerPitchTools(server)
+    registerScopeTools(server)
+    registerTaskTools(server)
+  },
+  {
+    serverInfo: {
+      name: 'Cycles MCP Server',
+      version: '1.0.0',
+    },
+  },
+  {
+    basePath: '/mcp',
+  }
+)
+
+const clerk = createClerkClient({
+  secretKey: process.env.CLERK_SECRET_KEY!,
+  publishableKey: process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY!,
+})
+
+const authHandler = withMcpAuth(
+  handler,
+  async (req, token) => {
+    if (!token) return undefined
+
+    try {
+      const result = await clerk.authenticateRequest(req, {
+        acceptsToken: 'oauth_token',
+      })
+      const authObject = result.toAuth()
+      if (!authObject || !authObject.userId) return undefined
+
+      return {
+        token,
+        clientId: ('clientId' in authObject ? authObject.clientId : null) ?? 'unknown',
+        scopes: ('scopes' in authObject ? authObject.scopes : null) ?? [],
+        extra: { userId: authObject.userId },
+      }
+    } catch (e) {
+      console.error('[MCP Auth] error:', e)
+      return undefined
+    }
+  },
+  {
+    required: true,
+    resourceMetadataPath: '/.well-known/oauth-protected-resource/mcp',
+  }
+)
+
+export { authHandler as GET, authHandler as POST, authHandler as DELETE }

--- a/src/lib/mcp/auth.ts
+++ b/src/lib/mcp/auth.ts
@@ -1,0 +1,55 @@
+import { clerkClient } from '@clerk/nextjs/server'
+import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js'
+
+/**
+ * Extract userId from MCP authInfo (set by verifyClerkToken).
+ */
+export function getUserId(authInfo?: AuthInfo): string {
+  const userId = authInfo?.extra?.userId
+  if (!userId || typeof userId !== 'string') {
+    throw new Error('Not authenticated')
+  }
+  return userId
+}
+
+/**
+ * Verify that a user is a member of the given organization.
+ */
+export async function verifyOrgMembership(
+  userId: string,
+  orgId: string
+): Promise<void> {
+  const client = await clerkClient()
+  const { data: memberships } =
+    await client.users.getOrganizationMembershipList({ userId })
+
+  const isMember = memberships.some((m) => m.organization.id === orgId)
+  if (!isMember) {
+    throw new Error(
+      `User is not a member of organization ${orgId}`
+    )
+  }
+}
+
+/**
+ * List organizations the user belongs to.
+ */
+export async function listUserOrgs(userId: string) {
+  const client = await clerkClient()
+  const { data: memberships } =
+    await client.users.getOrganizationMembershipList({ userId })
+
+  return memberships.map((m) => ({
+    id: m.organization.id,
+    name: m.organization.name,
+    slug: m.organization.slug,
+    role: m.role,
+  }))
+}
+
+/**
+ * Build a Liveblocks room ID from orgId and board slug.
+ */
+export function roomId(orgId: string, boardSlug: string): string {
+  return `${orgId}:${boardSlug}`
+}

--- a/src/lib/mcp/boards.ts
+++ b/src/lib/mcp/boards.ts
@@ -1,0 +1,239 @@
+import { z } from 'zod'
+import { nanoid } from 'nanoid'
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { liveblocks } from '@/lib/liveblocks'
+import { getUserId, verifyOrgMembership, listUserOrgs, roomId } from './auth'
+import { getStorage } from './storage'
+
+export function registerBoardTools(server: McpServer) {
+  server.tool(
+    'list_organizations',
+    'List organizations the authenticated user belongs to',
+    {},
+    async (_args, extra) => {
+      const userId = getUserId(extra.authInfo)
+      const orgs = await listUserOrgs(userId)
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(orgs, null, 2),
+          },
+        ],
+      }
+    }
+  )
+
+  server.tool(
+    'list_boards',
+    'List all boards for an organization',
+    {
+      orgId: z.string().describe('Organization ID'),
+      includeArchived: z
+        .boolean()
+        .optional()
+        .describe('Include archived boards (default: false)'),
+    },
+    async ({ orgId, includeArchived }, extra) => {
+      const userId = getUserId(extra.authInfo)
+      await verifyOrgMembership(userId, orgId)
+
+      const { data: rooms } = await liveblocks.getRooms({
+        query: `roomId^"${orgId}:"`,
+      })
+
+      const boards = rooms
+        .filter((room) => includeArchived || !room.metadata.archived)
+        .map((room) => ({
+          slug: room.id.split(':')[1],
+          title: room.metadata.title ?? 'Untitled',
+          archived: Boolean(room.metadata.archived),
+          createdOn: room.metadata.createdOn ?? null,
+          createdBy: room.metadata.createdBy ?? null,
+        }))
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(boards, null, 2),
+          },
+        ],
+      }
+    }
+  )
+
+  server.tool(
+    'get_board',
+    'Get board metadata along with all its pitches, scopes, and tasks',
+    {
+      orgId: z.string().describe('Organization ID'),
+      boardSlug: z.string().describe('Board slug'),
+    },
+    async ({ orgId, boardSlug }, extra) => {
+      const userId = getUserId(extra.authInfo)
+      await verifyOrgMembership(userId, orgId)
+
+      const rid = roomId(orgId, boardSlug)
+      const room = await liveblocks.getRoom(rid)
+      const storage = await getStorage(rid)
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(
+              {
+                slug: boardSlug,
+                title: room.metadata.title ?? 'Untitled',
+                archived: Boolean(room.metadata.archived),
+                pitches: storage.pitches ?? [],
+                scopes: storage.scopes ?? [],
+                tasks: storage.tasks ?? [],
+              },
+              null,
+              2
+            ),
+          },
+        ],
+      }
+    }
+  )
+
+  server.tool(
+    'create_board',
+    'Create a new board with a default pitch and scope',
+    {
+      orgId: z.string().describe('Organization ID'),
+      title: z.string().describe('Board title'),
+      slug: z
+        .string()
+        .regex(/^[a-z0-9-]+$/)
+        .min(5)
+        .describe(
+          'Board slug (lowercase letters, digits, dashes; min 5 characters)'
+        ),
+    },
+    async ({ orgId, title, slug }, extra) => {
+      const userId = getUserId(extra.authInfo)
+      await verifyOrgMembership(userId, orgId)
+
+      const rid = roomId(orgId, slug)
+
+      // Check if room already exists
+      try {
+        await liveblocks.getRoom(rid)
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Board with slug "${slug}" already exists`,
+            },
+          ],
+          isError: true,
+        }
+      } catch {
+        // Room doesn't exist, good to create
+      }
+
+      await liveblocks.createRoom(rid, {
+        metadata: {
+          title,
+          createdOn: new Date().toISOString(),
+          createdBy: userId,
+        },
+        defaultAccesses: ['room:write'],
+      })
+
+      const pitchId = nanoid()
+      const scopeId = nanoid()
+      await liveblocks.initializeStorageDocument(rid, {
+        liveblocksType: 'LiveObject',
+        data: {
+          tasks: { liveblocksType: 'LiveList', data: [] },
+          scopes: {
+            liveblocksType: 'LiveList',
+            data: [
+              {
+                liveblocksType: 'LiveObject',
+                data: {
+                  id: scopeId,
+                  pitchId,
+                  title: 'First scope',
+                  color: 'color-2',
+                  core: true,
+                },
+              },
+            ],
+          },
+          pitches: {
+            liveblocksType: 'LiveList',
+            data: [
+              {
+                liveblocksType: 'LiveObject',
+                data: { id: pitchId, title: 'First pitch' },
+              },
+            ],
+          },
+          info: {
+            liveblocksType: 'LiveObject',
+            data: { name: title },
+          },
+        },
+      })
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(
+              { slug, title, pitchId, scopeId },
+              null,
+              2
+            ),
+          },
+        ],
+      }
+    }
+  )
+
+  server.tool(
+    'archive_board',
+    'Archive a board',
+    {
+      orgId: z.string().describe('Organization ID'),
+      boardSlug: z.string().describe('Board slug'),
+    },
+    async ({ orgId, boardSlug }, extra) => {
+      const userId = getUserId(extra.authInfo)
+      await verifyOrgMembership(userId, orgId)
+
+      const rid = roomId(orgId, boardSlug)
+      await liveblocks.updateRoom(rid, { metadata: { archived: 'yes' } })
+
+      return {
+        content: [{ type: 'text', text: `Board "${boardSlug}" archived` }],
+      }
+    }
+  )
+
+  server.tool(
+    'restore_board',
+    'Restore an archived board',
+    {
+      orgId: z.string().describe('Organization ID'),
+      boardSlug: z.string().describe('Board slug'),
+    },
+    async ({ orgId, boardSlug }, extra) => {
+      const userId = getUserId(extra.authInfo)
+      await verifyOrgMembership(userId, orgId)
+
+      const rid = roomId(orgId, boardSlug)
+      await liveblocks.updateRoom(rid, { metadata: { archived: null } })
+
+      return {
+        content: [{ type: 'text', text: `Board "${boardSlug}" restored` }],
+      }
+    }
+  )
+}

--- a/src/lib/mcp/pitches.ts
+++ b/src/lib/mcp/pitches.ts
@@ -1,0 +1,200 @@
+import { z } from 'zod'
+import { nanoid } from 'nanoid'
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { getUserId, verifyOrgMembership, roomId } from './auth'
+import { getStorage, getStorageLson, writeStorageLson } from './storage'
+
+export function registerPitchTools(server: McpServer) {
+  server.tool(
+    'list_pitches',
+    'List pitches in a board',
+    {
+      orgId: z.string().describe('Organization ID'),
+      boardSlug: z.string().describe('Board slug'),
+      includeArchived: z
+        .boolean()
+        .optional()
+        .describe('Include archived pitches (default: false)'),
+    },
+    async ({ orgId, boardSlug, includeArchived }, extra) => {
+      const userId = getUserId(extra.authInfo)
+      await verifyOrgMembership(userId, orgId)
+
+      const storage = await getStorage(roomId(orgId, boardSlug))
+      const pitches = (storage.pitches as Record<string, unknown>[]) ?? []
+      const filtered = pitches.filter(
+        (p) => includeArchived || !p.archived
+      )
+
+      return {
+        content: [{ type: 'text', text: JSON.stringify(filtered, null, 2) }],
+      }
+    }
+  )
+
+  server.tool(
+    'get_pitch',
+    'Get a pitch with its scopes and tasks',
+    {
+      orgId: z.string().describe('Organization ID'),
+      boardSlug: z.string().describe('Board slug'),
+      pitchId: z.string().describe('Pitch ID'),
+    },
+    async ({ orgId, boardSlug, pitchId }, extra) => {
+      const userId = getUserId(extra.authInfo)
+      await verifyOrgMembership(userId, orgId)
+
+      const storage = await getStorage(roomId(orgId, boardSlug))
+      const pitches = (storage.pitches as Record<string, unknown>[]) ?? []
+      const scopes = (storage.scopes as Record<string, unknown>[]) ?? []
+      const tasks = (storage.tasks as Record<string, unknown>[]) ?? []
+
+      const pitch = pitches.find((p) => p.id === pitchId)
+      if (!pitch) {
+        return {
+          content: [{ type: 'text', text: `Pitch "${pitchId}" not found` }],
+          isError: true,
+        }
+      }
+
+      const pitchScopes = scopes.filter((s) => s.pitchId === pitchId)
+      const scopeIds = new Set(pitchScopes.map((s) => s.id))
+      const pitchTasks = tasks.filter((t) => scopeIds.has(t.scopeId as string))
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(
+              { ...pitch, scopes: pitchScopes, tasks: pitchTasks },
+              null,
+              2
+            ),
+          },
+        ],
+      }
+    }
+  )
+
+  server.tool(
+    'create_pitch',
+    'Create a new pitch in a board',
+    {
+      orgId: z.string().describe('Organization ID'),
+      boardSlug: z.string().describe('Board slug'),
+      title: z.string().describe('Pitch title'),
+      description: z.string().optional().describe('Pitch description'),
+      link: z.string().optional().describe('External link URL'),
+    },
+    async ({ orgId, boardSlug, title, description, link }, extra) => {
+      const userId = getUserId(extra.authInfo)
+      await verifyOrgMembership(userId, orgId)
+
+      const rid = roomId(orgId, boardSlug)
+      const lson = await getStorageLson(rid)
+      const root = lson.data as Record<string, unknown>
+      const pitchesList = root.pitches as { data: unknown[] }
+
+      const id = nanoid()
+      const pitchData: Record<string, unknown> = { id, title }
+      if (description) pitchData.description = description
+      if (link) pitchData.link = link
+
+      pitchesList.data.push({
+        liveblocksType: 'LiveObject',
+        data: pitchData,
+      })
+
+      await writeStorageLson(rid, lson)
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({ id, title, description, link }, null, 2),
+          },
+        ],
+      }
+    }
+  )
+
+  server.tool(
+    'update_pitch',
+    'Update pitch fields',
+    {
+      orgId: z.string().describe('Organization ID'),
+      boardSlug: z.string().describe('Board slug'),
+      pitchId: z.string().describe('Pitch ID'),
+      title: z.string().optional().describe('New title'),
+      description: z.string().optional().describe('New description'),
+      link: z.string().optional().describe('New link URL'),
+    },
+    async ({ orgId, boardSlug, pitchId, title, description, link }, extra) => {
+      const userId = getUserId(extra.authInfo)
+      await verifyOrgMembership(userId, orgId)
+
+      const rid = roomId(orgId, boardSlug)
+      const lson = await getStorageLson(rid)
+      const root = lson.data as Record<string, unknown>
+      const pitchesList = root.pitches as {
+        data: Array<{ data: Record<string, unknown> }>
+      }
+
+      const pitch = pitchesList.data.find((p) => p.data.id === pitchId)
+      if (!pitch) {
+        return {
+          content: [{ type: 'text', text: `Pitch "${pitchId}" not found` }],
+          isError: true,
+        }
+      }
+
+      if (title !== undefined) pitch.data.title = title
+      if (description !== undefined) pitch.data.description = description
+      if (link !== undefined) pitch.data.link = link
+
+      await writeStorageLson(rid, lson)
+
+      return {
+        content: [
+          { type: 'text', text: JSON.stringify(pitch.data, null, 2) },
+        ],
+      }
+    }
+  )
+
+  server.tool(
+    'archive_pitch',
+    'Archive a pitch',
+    {
+      orgId: z.string().describe('Organization ID'),
+      boardSlug: z.string().describe('Board slug'),
+      pitchId: z.string().describe('Pitch ID'),
+    },
+    async ({ orgId, boardSlug, pitchId }, extra) => {
+      const userId = getUserId(extra.authInfo)
+      await verifyOrgMembership(userId, orgId)
+
+      const rid = roomId(orgId, boardSlug)
+      const lson = await getStorageLson(rid)
+      const root = lson.data as Record<string, unknown>
+      const pitchesList = root.pitches as {
+        data: Array<{ data: Record<string, unknown> }>
+      }
+
+      const pitch = pitchesList.data.find((p) => p.data.id === pitchId)
+      if (!pitch) {
+        return {
+          content: [{ type: 'text', text: `Pitch "${pitchId}" not found` }],
+          isError: true,
+        }
+      }
+
+      pitch.data.archived = true
+      await writeStorageLson(rid, lson)
+
+      return {
+        content: [{ type: 'text', text: `Pitch "${pitchId}" archived` }],
+      }
+    }
+  )
+}

--- a/src/lib/mcp/scopes.ts
+++ b/src/lib/mcp/scopes.ts
@@ -113,10 +113,13 @@ export function registerScopeTools(server: McpServer) {
         .describe('New color (color-1 through color-8)'),
       progress: z
         .number()
+        .int()
         .min(0)
-        .max(1)
+        .max(8)
         .optional()
-        .describe('Progress (0 to 1)'),
+        .describe(
+          'Progress on the hill chart (0-8). 0-3: uphill/figuring out, 4: top of hill, 5-8: downhill/executing'
+        ),
       effort: z
         .number()
         .min(0)

--- a/src/lib/mcp/scopes.ts
+++ b/src/lib/mcp/scopes.ts
@@ -1,0 +1,228 @@
+import { z } from 'zod'
+import { nanoid } from 'nanoid'
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { getUserId, verifyOrgMembership, roomId } from './auth'
+import { getStorage, getStorageLson, writeStorageLson } from './storage'
+// Scope colors — must match liveblocks.config.ts
+const scopeColors = [
+  'color-1',
+  'color-2',
+  'color-3',
+  'color-4',
+  'color-5',
+  'color-6',
+  'color-7',
+  'color-8',
+] as const
+
+export function registerScopeTools(server: McpServer) {
+  server.tool(
+    'list_scopes',
+    'List scopes for a pitch',
+    {
+      orgId: z.string().describe('Organization ID'),
+      boardSlug: z.string().describe('Board slug'),
+      pitchId: z.string().describe('Pitch ID'),
+      includeArchived: z
+        .boolean()
+        .optional()
+        .describe('Include archived scopes (default: false)'),
+    },
+    async ({ orgId, boardSlug, pitchId, includeArchived }, extra) => {
+      const userId = getUserId(extra.authInfo)
+      await verifyOrgMembership(userId, orgId)
+
+      const storage = await getStorage(roomId(orgId, boardSlug))
+      const scopes = (storage.scopes as Record<string, unknown>[]) ?? []
+      const filtered = scopes.filter(
+        (s) => s.pitchId === pitchId && (includeArchived || !s.archived)
+      )
+
+      return {
+        content: [{ type: 'text', text: JSON.stringify(filtered, null, 2) }],
+      }
+    }
+  )
+
+  server.tool(
+    'create_scope',
+    'Create a new scope in a pitch',
+    {
+      orgId: z.string().describe('Organization ID'),
+      boardSlug: z.string().describe('Board slug'),
+      pitchId: z.string().describe('Pitch ID'),
+      title: z.string().describe('Scope title'),
+      description: z.string().optional().describe('Scope description'),
+      color: z
+        .enum(scopeColors)
+        .optional()
+        .describe(
+          'Scope color (color-1 through color-8). Auto-assigned if omitted.'
+        ),
+    },
+    async ({ orgId, boardSlug, pitchId, title, description, color }, extra) => {
+      const userId = getUserId(extra.authInfo)
+      await verifyOrgMembership(userId, orgId)
+
+      const rid = roomId(orgId, boardSlug)
+      const lson = await getStorageLson(rid)
+      const root = lson.data as Record<string, unknown>
+      const scopesList = root.scopes as { data: Array<{ data: Record<string, unknown> }> }
+
+      // Auto-assign color if not provided
+      const assignedColor =
+        color ?? autoAssignColor(scopesList.data, pitchId)
+
+      const id = nanoid()
+      const scopeData: Record<string, unknown> = {
+        id,
+        pitchId,
+        title,
+        color: assignedColor,
+        core: true,
+      }
+      if (description) scopeData.description = description
+
+      scopesList.data.push({
+        liveblocksType: 'LiveObject',
+        data: scopeData,
+      } as never)
+
+      await writeStorageLson(rid, lson)
+
+      return {
+        content: [
+          { type: 'text', text: JSON.stringify(scopeData, null, 2) },
+        ],
+      }
+    }
+  )
+
+  server.tool(
+    'update_scope',
+    'Update scope fields',
+    {
+      orgId: z.string().describe('Organization ID'),
+      boardSlug: z.string().describe('Board slug'),
+      scopeId: z.string().describe('Scope ID'),
+      title: z.string().optional().describe('New title'),
+      description: z.string().optional().describe('New description'),
+      color: z
+        .enum(scopeColors)
+        .optional()
+        .describe('New color (color-1 through color-8)'),
+      progress: z
+        .number()
+        .min(0)
+        .max(1)
+        .optional()
+        .describe('Progress (0 to 1)'),
+      effort: z
+        .number()
+        .min(0)
+        .max(1)
+        .optional()
+        .describe('Effort estimate (0 to 1)'),
+      impact: z
+        .number()
+        .min(0)
+        .max(1)
+        .optional()
+        .describe('Impact estimate (0 to 1)'),
+    },
+    async (
+      { orgId, boardSlug, scopeId, title, description, color, progress, effort, impact },
+      extra
+    ) => {
+      const userId = getUserId(extra.authInfo)
+      await verifyOrgMembership(userId, orgId)
+
+      const rid = roomId(orgId, boardSlug)
+      const lson = await getStorageLson(rid)
+      const root = lson.data as Record<string, unknown>
+      const scopesList = root.scopes as {
+        data: Array<{ data: Record<string, unknown> }>
+      }
+
+      const scope = scopesList.data.find((s) => s.data.id === scopeId)
+      if (!scope) {
+        return {
+          content: [{ type: 'text', text: `Scope "${scopeId}" not found` }],
+          isError: true,
+        }
+      }
+
+      if (title !== undefined) scope.data.title = title
+      if (description !== undefined) scope.data.description = description
+      if (color !== undefined) scope.data.color = color
+      if (progress !== undefined) scope.data.progress = progress
+      if (effort !== undefined) scope.data.effort = effort
+      if (impact !== undefined) scope.data.impact = impact
+
+      await writeStorageLson(rid, lson)
+
+      return {
+        content: [
+          { type: 'text', text: JSON.stringify(scope.data, null, 2) },
+        ],
+      }
+    }
+  )
+
+  server.tool(
+    'archive_scope',
+    'Archive a scope',
+    {
+      orgId: z.string().describe('Organization ID'),
+      boardSlug: z.string().describe('Board slug'),
+      scopeId: z.string().describe('Scope ID'),
+    },
+    async ({ orgId, boardSlug, scopeId }, extra) => {
+      const userId = getUserId(extra.authInfo)
+      await verifyOrgMembership(userId, orgId)
+
+      const rid = roomId(orgId, boardSlug)
+      const lson = await getStorageLson(rid)
+      const root = lson.data as Record<string, unknown>
+      const scopesList = root.scopes as {
+        data: Array<{ data: Record<string, unknown> }>
+      }
+
+      const scope = scopesList.data.find((s) => s.data.id === scopeId)
+      if (!scope) {
+        return {
+          content: [{ type: 'text', text: `Scope "${scopeId}" not found` }],
+          isError: true,
+        }
+      }
+
+      scope.data.archived = true
+      await writeStorageLson(rid, lson)
+
+      return {
+        content: [{ type: 'text', text: `Scope "${scopeId}" archived` }],
+      }
+    }
+  )
+}
+
+/**
+ * Auto-assign a scope color by picking the next unused color for the pitch.
+ */
+function autoAssignColor(
+  existingScopes: Array<{ data: Record<string, unknown> }>,
+  pitchId: string
+): string {
+  const usedColors = new Set(
+    existingScopes
+      .filter((s) => s.data.pitchId === pitchId && !s.data.archived)
+      .map((s) => s.data.color)
+  )
+
+  for (const color of scopeColors) {
+    if (!usedColors.has(color)) return color
+  }
+
+  // All colors used, cycle back
+  return scopeColors[existingScopes.length % scopeColors.length]
+}

--- a/src/lib/mcp/storage.ts
+++ b/src/lib/mcp/storage.ts
@@ -1,0 +1,33 @@
+import { liveblocks } from '@/lib/liveblocks'
+import type { JsonObject } from '@liveblocks/node'
+
+/**
+ * Read room storage as plain JSON (pitches, scopes, tasks become arrays).
+ */
+export async function getStorage(roomId: string): Promise<JsonObject> {
+  return liveblocks.getStorageDocument(roomId, 'json')
+}
+
+/**
+ * Read room storage as LSON (preserves LiveObject/LiveList type metadata).
+ */
+export async function getStorageLson(roomId: string) {
+  return liveblocks.getStorageDocument(roomId, 'plain-lson')
+}
+
+/**
+ * Write storage by reinitializing with modified LSON.
+ * This briefly disconnects live users (they auto-reconnect).
+ *
+ * Steps: delete existing storage, then initialize with new data.
+ */
+export async function writeStorageLson(
+  roomId: string,
+  lson: Record<string, unknown>
+) {
+  await liveblocks.deleteStorageDocument(roomId)
+  await liveblocks.initializeStorageDocument(
+    roomId,
+    lson as Parameters<typeof liveblocks.initializeStorageDocument>[1]
+  )
+}

--- a/src/lib/mcp/tasks.ts
+++ b/src/lib/mcp/tasks.ts
@@ -1,0 +1,237 @@
+import { z } from 'zod'
+import { nanoid } from 'nanoid'
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { getUserId, verifyOrgMembership, roomId } from './auth'
+import { getStorage, getStorageLson, writeStorageLson } from './storage'
+
+const taskStatusEnum = z.enum(['todo', 'in_progress', 'done'])
+const taskTypeEnum = z.enum(['task', 'optional', 'bug', 'question'])
+
+export function registerTaskTools(server: McpServer) {
+  server.tool(
+    'list_tasks',
+    'List tasks in a scope',
+    {
+      orgId: z.string().describe('Organization ID'),
+      boardSlug: z.string().describe('Board slug'),
+      scopeId: z.string().describe('Scope ID'),
+      includeArchived: z
+        .boolean()
+        .optional()
+        .describe('Include archived tasks (default: false)'),
+    },
+    async ({ orgId, boardSlug, scopeId, includeArchived }, extra) => {
+      const userId = getUserId(extra.authInfo)
+      await verifyOrgMembership(userId, orgId)
+
+      const storage = await getStorage(roomId(orgId, boardSlug))
+      const tasks = (storage.tasks as Record<string, unknown>[]) ?? []
+      const filtered = tasks.filter(
+        (t) => t.scopeId === scopeId && (includeArchived || !t.archived)
+      )
+
+      return {
+        content: [{ type: 'text', text: JSON.stringify(filtered, null, 2) }],
+      }
+    }
+  )
+
+  server.tool(
+    'create_task',
+    'Create a task in a scope',
+    {
+      orgId: z.string().describe('Organization ID'),
+      boardSlug: z.string().describe('Board slug'),
+      scopeId: z.string().describe('Scope ID'),
+      title: z.string().describe('Task title'),
+      status: taskStatusEnum.optional().describe('Task status (default: todo)'),
+      type: taskTypeEnum.optional().describe('Task type (default: task)'),
+      assignee: z.string().optional().describe('Assignee user ID'),
+    },
+    async ({ orgId, boardSlug, scopeId, title, status, type, assignee }, extra) => {
+      const userId = getUserId(extra.authInfo)
+      await verifyOrgMembership(userId, orgId)
+
+      const rid = roomId(orgId, boardSlug)
+      const lson = await getStorageLson(rid)
+      const root = lson.data as Record<string, unknown>
+      const tasksList = root.tasks as { data: unknown[] }
+
+      const id = nanoid()
+      const taskData: Record<string, unknown> = {
+        id,
+        scopeId,
+        title,
+        status: status ?? 'todo',
+      }
+      if (type) taskData.type = type
+      if (assignee) taskData.assignee = assignee
+
+      tasksList.data.push({
+        liveblocksType: 'LiveObject',
+        data: taskData,
+      })
+
+      await writeStorageLson(rid, lson)
+
+      return {
+        content: [
+          { type: 'text', text: JSON.stringify(taskData, null, 2) },
+        ],
+      }
+    }
+  )
+
+  server.tool(
+    'update_task',
+    'Update task fields',
+    {
+      orgId: z.string().describe('Organization ID'),
+      boardSlug: z.string().describe('Board slug'),
+      taskId: z.string().describe('Task ID'),
+      title: z.string().optional().describe('New title'),
+      status: taskStatusEnum.optional().describe('New status'),
+      type: taskTypeEnum.optional().describe('New type'),
+      assignee: z.string().optional().describe('New assignee user ID'),
+      scopeId: z.string().optional().describe('Move to a different scope'),
+    },
+    async (
+      { orgId, boardSlug, taskId, title, status, type, assignee, scopeId },
+      extra
+    ) => {
+      const userId = getUserId(extra.authInfo)
+      await verifyOrgMembership(userId, orgId)
+
+      const rid = roomId(orgId, boardSlug)
+      const lson = await getStorageLson(rid)
+      const root = lson.data as Record<string, unknown>
+      const tasksList = root.tasks as {
+        data: Array<{ data: Record<string, unknown> }>
+      }
+
+      const task = tasksList.data.find((t) => t.data.id === taskId)
+      if (!task) {
+        return {
+          content: [{ type: 'text', text: `Task "${taskId}" not found` }],
+          isError: true,
+        }
+      }
+
+      if (title !== undefined) task.data.title = title
+      if (status !== undefined) task.data.status = status
+      if (type !== undefined) task.data.type = type
+      if (assignee !== undefined) task.data.assignee = assignee
+      if (scopeId !== undefined) task.data.scopeId = scopeId
+
+      await writeStorageLson(rid, lson)
+
+      return {
+        content: [
+          { type: 'text', text: JSON.stringify(task.data, null, 2) },
+        ],
+      }
+    }
+  )
+
+  server.tool(
+    'archive_task',
+    'Archive a task',
+    {
+      orgId: z.string().describe('Organization ID'),
+      boardSlug: z.string().describe('Board slug'),
+      taskId: z.string().describe('Task ID'),
+    },
+    async ({ orgId, boardSlug, taskId }, extra) => {
+      const userId = getUserId(extra.authInfo)
+      await verifyOrgMembership(userId, orgId)
+
+      const rid = roomId(orgId, boardSlug)
+      const lson = await getStorageLson(rid)
+      const root = lson.data as Record<string, unknown>
+      const tasksList = root.tasks as {
+        data: Array<{ data: Record<string, unknown> }>
+      }
+
+      const task = tasksList.data.find((t) => t.data.id === taskId)
+      if (!task) {
+        return {
+          content: [{ type: 'text', text: `Task "${taskId}" not found` }],
+          isError: true,
+        }
+      }
+
+      task.data.archived = true
+      await writeStorageLson(rid, lson)
+
+      return {
+        content: [{ type: 'text', text: `Task "${taskId}" archived` }],
+      }
+    }
+  )
+
+  server.tool(
+    'bulk_create_tasks',
+    'Create multiple tasks at once in a scope',
+    {
+      orgId: z.string().describe('Organization ID'),
+      boardSlug: z.string().describe('Board slug'),
+      scopeId: z.string().describe('Scope ID'),
+      tasks: z
+        .array(
+          z.object({
+            title: z.string().describe('Task title'),
+            status: taskStatusEnum
+              .optional()
+              .describe('Task status (default: todo)'),
+            type: taskTypeEnum.optional().describe('Task type (default: task)'),
+            assignee: z.string().optional().describe('Assignee user ID'),
+          })
+        )
+        .describe('Array of tasks to create'),
+    },
+    async ({ orgId, boardSlug, scopeId, tasks }, extra) => {
+      const userId = getUserId(extra.authInfo)
+      await verifyOrgMembership(userId, orgId)
+
+      const rid = roomId(orgId, boardSlug)
+      const lson = await getStorageLson(rid)
+      const root = lson.data as Record<string, unknown>
+      const tasksList = root.tasks as { data: unknown[] }
+
+      const created: Record<string, unknown>[] = []
+
+      for (const t of tasks) {
+        const id = nanoid()
+        const taskData: Record<string, unknown> = {
+          id,
+          scopeId,
+          title: t.title,
+          status: t.status ?? 'todo',
+        }
+        if (t.type) taskData.type = t.type
+        if (t.assignee) taskData.assignee = t.assignee
+
+        tasksList.data.push({
+          liveblocksType: 'LiveObject',
+          data: taskData,
+        })
+        created.push(taskData)
+      }
+
+      await writeStorageLson(rid, lson)
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(
+              { created: created.length, tasks: created },
+              null,
+              2
+            ),
+          },
+        ],
+      }
+    }
+  )
+}

--- a/src/lib/users.ts
+++ b/src/lib/users.ts
@@ -13,8 +13,9 @@ export async function getOrganizationUsers(
 ): Promise<OrganizationUser[]> {
   if (!organizationId) return []
 
+  const client = await clerkClient()
   const { data: memberships } =
-    await clerkClient.organizations.getOrganizationMembershipList({
+    await client.organizations.getOrganizationMembershipList({
       organizationId,
       limit: 100,
     })

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,7 +1,30 @@
-import { clerkMiddleware } from '@clerk/nextjs/server'
+import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
 
-export default clerkMiddleware()
+const isPublicRoute = createRouteMatcher([
+  '/.well-known/(.*)',
+  '/api/well-known/(.*)',
+])
+
+const isMcpRoute = createRouteMatcher(['/mcp/(.*)'])
+
+const clerkHandler = clerkMiddleware(async (auth, req) => {
+  if (!isPublicRoute(req)) {
+    await auth.protect()
+  }
+})
+
+export default function middleware(req: NextRequest) {
+  // MCP routes handle their own OAuth auth via @vercel/mcp-adapter —
+  // skip Clerk middleware which would reject OAuth bearer tokens
+  if (isMcpRoute(req)) {
+    return NextResponse.next()
+  }
+
+  return clerkHandler(req, {} as never)
+}
 
 export const config = {
-  matcher: ['/((?!.*\\..*|_next).*)', '/', '/(api|trpc)(.*)'],
+  matcher: ['/((?!.*\\..*|_next).*)', '/', '/(api|trpc)(.*)', '/mcp/(.*)'],
 }


### PR DESCRIPTION
## Summary

- Adds an MCP (Model Context Protocol) server so Claude can read and write Cycles data via authenticated OAuth
- 21 tools: boards (list, get, create, archive, restore), pitches (list, get, create, update, archive), scopes (list, create, update, archive), tasks (list, create, update, archive, bulk create), and list_organizations
- OAuth discovery via `/.well-known` endpoints (rewrites to `/api/well-known/` for Next.js compat)
- Auth: Clerk OAuth flow with `@clerk/backend` `authenticateRequest` for token verification
- Upgrades Clerk v5→v6 (`auth()` now async, `clerkClient()` now async), Zod v3→v4, Next.js to 14.2.35

## Test plan

- [ ] Enable "Dynamic Client Registration" in Clerk Dashboard OAuth settings
- [ ] `curl localhost:3033/.well-known/oauth-authorization-server` returns Clerk OAuth metadata
- [ ] `curl localhost:3033/.well-known/oauth-protected-resource/mcp` returns protected resource metadata
- [ ] `curl localhost:3033/mcp/mcp` returns `{"error":"invalid_token",...}` (expected without token)
- [ ] Add MCP server to Claude Desktop via `npx mcp-remote http://localhost:3033/mcp/mcp`
- [ ] OAuth flow triggers Clerk sign-in and completes
- [ ] `list_organizations` → `list_boards` → `get_board` tools work end-to-end
- [ ] Existing app (boards list, board detail) still works after Clerk v6 migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)